### PR TITLE
Fix `[compat]` entries in `Project.toml`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ SimplePosets = "b2aef97b-4721-5af9-b440-0bad754dc5ba"
 
 [compat]
 julia = "1.5"
-SimpleGraphs = "0"
+SimpleGraphs = "0.2, 0.3, 0.4, 0.5, 0.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
In the General registry, we now **strongly** discourage users from having `[compat]` entries of the form:
```toml
SomePackage = "0"
```

These `[compat]` entries are problematic because they include an infinite number of breaking releases.

This pull request fixes the `[compat]` entries in the `Project.toml` file for this package.

cc: @scheinerman